### PR TITLE
fix: improve types exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
         "require": "./dist/node/cjs/index.js"
       },
       "browser": "./dist/browser/esm/index.js",
-      "umd": "./dist/browser/umd/index.js"
+      "umd": "./dist/browser/umd/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This PR improves how types are exported in `package.json`.